### PR TITLE
Don't create sourcemap pointing to unpublished sources

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "target": "es2017",
     "noImplicitAny": true,
     "moduleResolution": "node",
-    "sourceMap": true,
     "outDir": "build",
     "rootDir": "src",
     "jsx": "react-jsx"


### PR DESCRIPTION
Don't create sourcemap pointing to unpublished sources. Addresses [this issue](https://github.com/sunknudsen/react-node-to-string/issues/4).